### PR TITLE
Pin ament-black to the released Python 3.14 / black>=26.3 fix (0.2.7, v0.0.12)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "ament_lint_pre_commit"
 description = "Out-of-the-box ament_lint hooks for pre-commit"
-version = "0.0.11"
+version = "0.0.12"
 readme = "README.md"
 license = {file = "LICENSE"}
 authors = [
@@ -9,8 +9,14 @@ authors = [
 ]
 
 requires-python = ">=3.10"
+# Pinned to the botsandus/ament_black#18 head commit (Python 3.14 + black >= 26.3.0
+# fix: maybe_use_uvloop import fallback, and black/uvloop unpinned in setup.py).
+# The previous @noble_fix branch pinned black==21.12b0 + uvloop==0.17.0 (no py3.14
+# wheels) and still imported the removed black.concurrency.maybe_install_uvloop.
+# TODO: repoint to @v0.2.7 (or @main) once #18 merges and 0.2.7 is released.
+# https://github.com/botsandus/ament_black/pull/18
 dependencies = [
-  "ament-black @ git+https://github.com/botsandus/ament_black.git@noble_fix#subdirectory=ament_black"
+  "ament-black @ git+https://github.com/botsandus/ament_black.git@4a527225e68dcbffe1c97afb38f4a69962aa7030#subdirectory=ament_black"
 ]
 
 classifiers  = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,14 +9,8 @@ authors = [
 ]
 
 requires-python = ">=3.10"
-# Pinned to the botsandus/ament_black#18 head commit (Python 3.14 + black >= 26.3.0
-# fix: maybe_use_uvloop import fallback, and black/uvloop unpinned in setup.py).
-# The previous @noble_fix branch pinned black==21.12b0 + uvloop==0.17.0 (no py3.14
-# wheels) and still imported the removed black.concurrency.maybe_install_uvloop.
-# TODO: repoint to @v0.2.7 (or @main) once #18 merges and 0.2.7 is released.
-# https://github.com/botsandus/ament_black/pull/18
 dependencies = [
-  "ament-black @ git+https://github.com/botsandus/ament_black.git@4a527225e68dcbffe1c97afb38f4a69962aa7030#subdirectory=ament_black"
+  "ament-black @ git+https://github.com/botsandus/ament_black.git@0.2.7#subdirectory=ament_black"
 ]
 
 classifiers  = [


### PR DESCRIPTION
## Why

The `ament_black` hook is `language: python`, so pre-commit pip-installs ament-black into a venv built with the host Python. On **Python 3.14 it fails**: the dependency tracked the stale `noble_fix` branch of `botsandus/ament_black`, whose `setup.py` pins `black==21.12b0` + `uvloop==0.17.0` (no py3.14 wheels → install fails) and whose `main.py` still imports the removed `black.concurrency.maybe_install_uvloop` (black renamed it to `maybe_use_uvloop` in 26.3.0, [psf/black#4996](https://github.com/psf/black/pull/4996)).

## Change

[`botsandus/ament_black#18`](https://github.com/botsandus/ament_black/pull/18) is now **merged** and released as **`0.2.7`**, which:
- adds a `maybe_install_uvloop` / `maybe_use_uvloop` import fallback, and
- unpins `black`/`uvloop` in `setup.py` (current black 26.x and uvloop 0.22.1 ship py3.14 wheels).

Pin the dependency to the released tag `0.2.7` (note: the tag has no `v` prefix) instead of the PR head commit.

Released as `0.0.12` — this is the first release of the fix (`v0.0.12` was never tagged), so the repoint folds into that version rather than introducing a phantom `0.0.13`.

Verified: an isolated venv install from the tag yields `ament_black 0.2.7` and `ament_black --reformat` reformats correctly on Python 3.14 with black 26.5.1.

## Note for consumers

Repos that pin this hook by `rev:` (e.g. `auto-sandbox/.pre-commit-config.yaml`) should bump to `v0.0.12` once this is merged **and tagged** `v0.0.12`.